### PR TITLE
fix(deps): Add runtime dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,8 @@
           # System libraries
           openssl
           pkg-config
+          stdenv.cc.cc
+          bzip2
           
           # Runtime dependencies
           sox

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,10 @@ let
 
   # System libraries needed for building
   systemLibs = with pkgs; [
+    # System libraries
+    bzip2
+    stdenv.cc.cc
+
     # Audio support
     alsa-lib
     alsa-lib.dev


### PR DESCRIPTION
Without this change, running the resulting build on NixOS results in the following error:
```
./target/debug/jambi: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
```